### PR TITLE
Adaptations of the `develop` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ src/version/version.h
 .directory
 notUsed
 *.swp
+
+.vscode

--- a/tools/developer/taptest.sh
+++ b/tools/developer/taptest.sh
@@ -37,8 +37,8 @@ QUIET="-v"
 QUIET="-q"
 
 PGDATABASE="___pgr___test___"
-PGRVERSION="3.6.1 3.6.0 3.5.1 3.5.0 3.2.0 3.1.3 3.0.6"
-PGRVERSION="3.7.0"
+PGRVERSION="3.7.0 3.6.1 3.6.0 3.5.1 3.5.0 3.2.0 3.1.3 3.0.6"
+PGRVERSION="4.0.0"
 
 
 for v in ${PGRVERSION}


### PR DESCRIPTION
Fix:
- Adaptation of the test script: tests failed, because version 4.0.0 was not installed and used, even though it was the one which was compiled;
- Adaptation of the `.gitignore`.