### PR TITLE
Shortest path algo

### DIFF
--- a/include/contraction/bdhDijkstra.hpp
+++ b/include/contraction/bdhDijkstra.hpp
@@ -1,0 +1,142 @@
+/*PGR-GNU*****************************************************************
+File: bdhDijkstra.hpp
+
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+Function's developer:
+Oslandia - Aurélie Bousquet - 2024
+Mail: aurelie.bousquet@oslandia.com / contact@oslandia.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+
+#ifndef INCLUDE_CONTRACTION_BDH_DIJKSTRA_HPP_
+#define INCLUDE_CONTRACTION_BDH_DIJKSTRA_HPP_
+#pragma once
+
+#include <string>
+#include <queue>
+#include <utility>
+#include <vector>
+#include <limits>
+#include <functional>
+
+#include "cpp_common/bidirectional.hpp"
+#include "cpp_common/basePath_SSEC.hpp"
+#include "contraction/contractionGraph.hpp"
+
+namespace pgrouting {
+namespace contraction {
+
+template < typename G >
+class Pgr_bdhDijkstra : public Pgr_bidirectional<G> {
+    typedef typename Pgr_bidirectional<G>::V V;
+    typedef typename Pgr_bidirectional<G>::E E;
+    typedef typename Pgr_bidirectional<G>::Cost_Vertex_pair Cost_Vertex_pair;
+
+    using Pgr_bidirectional<G>::graph;
+    using Pgr_bidirectional<G>::m_log;
+    using Pgr_bidirectional<G>::v_source;
+    using Pgr_bidirectional<G>::v_target;
+
+    using Pgr_bidirectional<G>::backward_predecessor;
+    using Pgr_bidirectional<G>::backward_queue;
+    using Pgr_bidirectional<G>::backward_finished;
+    using Pgr_bidirectional<G>::backward_cost;
+    using Pgr_bidirectional<G>::backward_edge;
+
+    using Pgr_bidirectional<G>::forward_predecessor;
+    using Pgr_bidirectional<G>::forward_queue;
+    using Pgr_bidirectional<G>::forward_finished;
+    using Pgr_bidirectional<G>::forward_cost;
+    using Pgr_bidirectional<G>::forward_edge;
+
+    using Pgr_bidirectional<G>::bidirectional;
+
+ public:
+    explicit Pgr_bdhDijkstra(G &pgraph):
+        Pgr_bidirectional<G>(pgraph) {
+            m_log << "pgr_bdhDijkstra constructor\n";
+        }
+
+    ~Pgr_bdhDijkstra() = default;
+
+    Path pgr_bdhDijkstra(V start_vertex, V end_vertex, bool only_cost) {
+        m_log << "pgr_bdhDijkstra\n";
+        v_source = start_vertex;
+        v_target = end_vertex;
+
+        return bidirectional(only_cost);
+    }
+
+    using Pgr_bidirectional<G>::log;
+    using Pgr_bidirectional<G>::clean_log;
+
+ private:
+    void explore_forward(const Cost_Vertex_pair &node) {
+        typename G::EO_i out, out_end;
+
+        auto current_cost = node.first;
+        auto current_node = node.second;
+
+        for (boost::tie(out, out_end) = out_edges(current_node, graph.graph);
+                out != out_end; ++out) {
+            auto edge_cost = graph[*out].cost;
+            auto next_node = graph.adjacent(current_node, *out);
+
+            if (forward_finished[next_node]) continue;
+
+            if (edge_cost + current_cost < forward_cost[next_node]) {
+                forward_cost[next_node] = edge_cost + current_cost;
+                forward_predecessor[next_node] = current_node;
+                forward_edge[next_node] = graph[*out].id;
+                forward_queue.push({forward_cost[next_node], next_node});
+            }
+        }
+        forward_finished[current_node] = true;
+    }
+
+    void explore_backward(const Cost_Vertex_pair &node) {
+        typename G::EI_i in, in_end;
+
+        auto current_cost = node.first;
+        auto current_node = node.second;
+
+        for (boost::tie(in, in_end) = in_edges(current_node, graph.graph);
+                in != in_end; ++in) {
+            auto edge_cost = graph[*in].cost;
+            auto next_node = graph.adjacent(current_node, *in);
+
+            if (backward_finished[next_node]) continue;
+
+            if (edge_cost + current_cost < backward_cost[next_node]) {
+                backward_cost[next_node] = edge_cost + current_cost;
+                backward_predecessor[next_node] = current_node;
+                backward_edge[next_node] = graph[*in].id;
+                backward_queue.push({backward_cost[next_node], next_node});
+            }
+        }
+        backward_finished[current_node] = true;
+    }
+};
+
+}  // namespace contraction
+}  // namespace pgrouting
+
+#endif  // INCLUDE_CONTRACTION_BDH_DIJKSTRA_HPP_

--- a/include/contraction/contractionGraph.hpp
+++ b/include/contraction/contractionGraph.hpp
@@ -51,7 +51,8 @@ namespace pgrouting {
 namespace graph {
 
 template <class G, bool t_directed>
-class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed> {
+class contractionGraph :
+        public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed> {
  public:
     using V = typename boost::graph_traits<G>::vertex_descriptor;
     using E = typename boost::graph_traits<G>::edge_descriptor;
@@ -59,13 +60,15 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     using EI_i = typename boost::graph_traits<G>::in_edge_iterator;
     using E_i = typename boost::graph_traits<G>::edge_iterator;
     using V_p = typename std::pair<double, V>;
-    using PQ = typename std::priority_queue<V_p, std::vector<V_p>, std::greater<V_p>>;
+    using PQ = typename std::priority_queue<V_p, std::vector<V_p>,
+            std::greater<V_p>>;
 
     // Constructors
     /*!
         Prepares the _graph_ to be of type *directed*
     */
-    explicit contractionGraph<G, t_directed>() : Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
+    explicit contractionGraph<G, t_directed>() :
+        Pgr_base_graph<G, CH_vertex, CH_edge, t_directed>() {
         min_edge_id = 0;
     }
 
@@ -101,27 +104,31 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     }
 
     /*!
-        @brief defines the metric and hierarchy at the level of the nodes, from a given priority queue
+        @brief defines the metric and hierarchy at the level of the nodes,
+        from a given priority queue
         @param [in] PQ priority_queue
         @return void
     */
     void set_vertices_metric_and_hierarchy(
-        PQ priority_queue,
-        std::ostringstream &log) {
+            PQ priority_queue,
+            std::ostringstream &log) {
         int64_t i = 0;
         while (!priority_queue.empty()) {
             i++;
             std::pair<double, V> ordered_vertex = priority_queue.top();
             priority_queue.pop();
 
-            (this->graph[ordered_vertex.second]).set_metric(ordered_vertex.first);
+            (this->graph[ordered_vertex.second]).set_metric(
+                ordered_vertex.first);
             (this->graph[ordered_vertex.second]).set_vertex_order(i);
 
             log << "(" << ordered_vertex.first << ", "
                 << (this->graph[ordered_vertex.second]).id
                 << ")" << std::endl;
-            log << " metric = " << get_vertex_metric((this->graph[ordered_vertex.second]).id)
-                << " order = " << get_vertex_order((this->graph[ordered_vertex.second]).id)
+            log << " metric = " << get_vertex_metric(
+                    (this->graph[ordered_vertex.second]).id)
+                << " order = " << get_vertex_order(
+                    (this->graph[ordered_vertex.second]).id)
                 << std::endl;
         }
     }
@@ -157,7 +164,9 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
             V u, v;
             u = this->vertices_map[it->source];
             v = this->vertices_map[it->target];
-            log << "Shortcut " << it->id << "(" << it->source << ", " << it->target << ")" << std::endl;
+            log << "Shortcut " << it->id << "("
+                << it->source << ", " << it->target
+                << ")" << std::endl;
             add_shortcut(*it, u, v);
         }
     }
@@ -170,11 +179,13 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     */
     Identifiers<V> find_adjacent_vertices(V v) const {
         Identifiers<V> adjacent_vertices;
-        for (const auto &e:
-            boost::make_iterator_range(out_edges(v, this->graph)))
+        for (const auto &e : boost::make_iterator_range(
+                out_edges(v, this->graph)))
             adjacent_vertices += this->adjacent(v, e);
-        for (const auto &e:
-            boost::make_iterator_range(in_edges(v, this->graph)))
+
+        for (const auto &e : boost::make_iterator_range(
+                in_edges(v, this->graph)))
+
             adjacent_vertices += this->adjacent(v, e);
 
         return adjacent_vertices;
@@ -188,7 +199,8 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     Identifiers<V> find_adjacent_out_vertices(V v) const {
         Identifiers<V> adjacent_vertices;
 
-        for (const auto &out : boost::make_iterator_range(out_edges(v, this->graph)))
+        for (const auto &out : boost::make_iterator_range(
+                out_edges(v, this->graph)))
             adjacent_vertices += this->adjacent(v, out);
 
         return adjacent_vertices;
@@ -202,7 +214,8 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     Identifiers<V> find_adjacent_in_vertices(V v) const {
         Identifiers<V> adjacent_vertices;
 
-        for (const auto &in : boost::make_iterator_range(in_edges(v, this->graph)))
+        for (const auto &in : boost::make_iterator_range(
+                in_edges(v, this->graph)))
             adjacent_vertices += this->adjacent(v, in);
 
         return adjacent_vertices;
@@ -227,7 +240,8 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
             eids.begin(),
             eids.end(),
             [&](E lhs, E rhs) {
-                return -1 * ((this->graph)[lhs]).id < -1 * ((this->graph)[rhs]).id;
+                return -1 * ((this->graph)[lhs]).id
+                        < -1 * ((this->graph)[rhs]).id;
             });
 
         return eids;
@@ -239,8 +253,10 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     */
     Identifiers<int64_t> get_modified_vertices() {
         Identifiers<int64_t> vids;
-        for (const auto &v : boost::make_iterator_range(boost::vertices(this->graph))) {
-            if ((this->graph[v].vertex_order > 0) || ((this->graph[v]).has_contracted_vertices())) {
+        for (const auto &v :
+                boost::make_iterator_range(boost::vertices(this->graph))) {
+            if ((this->graph[v].vertex_order > 0)
+            || ((this->graph[v]).has_contracted_vertices())) {
                 vids += (this->graph[v]).id;
             }
         }
@@ -281,8 +297,8 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
         }
 
         pgassert(this->is_undirected());
-        for (const auto &e:
-            boost::make_iterator_range(out_edges(u, this->graph))) {
+        for (const auto &e : boost::make_iterator_range(
+            out_edges(u, this->graph))) {
             if (this->adjacent(u, e) == v) {
                 contracted_vertices +=
                     (this->graph[e]).get_contracted_vertices();
@@ -300,11 +316,13 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
         @brief tests if the edges sequence (u, v), (v, w) exists in the graph
     */
     bool has_u_v_w(V u, V v, V w) const {
-        return boost::edge(u, v, this->graph).second && boost::edge(v, w, this->graph).second;
+        return boost::edge(u, v, this->graph).second
+            && boost::edge(v, w, this->graph).second;
     }
 
     /*!
-        @brief tests if v is in the middle of two edges with no possible bifurcation in v
+        @brief tests if v is in the middle of two edges
+        with no possible bifurcation in v
     */
     bool is_linear(V v) {
         // Checking adjacent vertices constraint
@@ -367,16 +385,19 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
              * u -> v -> w
              */
             ||
-            (has_u_v_w(u, v, w) && !(boost::edge(v, u, this->graph).second || boost::edge(w, v, this->graph).second))
+            (has_u_v_w(u, v, w) && !(boost::edge(v, u, this->graph).second
+            || boost::edge(w, v, this->graph).second))
             /*
              * u <- v <- w
              */
             ||
-            (has_u_v_w(w, v, u) && !(boost::edge(v, w, this->graph).second || boost::edge(u, v, this->graph).second));
+            (has_u_v_w(w, v, u) && !(boost::edge(v, w, this->graph).second
+            || boost::edge(u, v, this->graph).second));
     }
 
     /*!
-        @brief builds the shortcut information and adds it during contraction or afterwards to copy them to the source graph
+        @brief builds the shortcut information and adds it
+        during contraction or afterwards to copy them to the source graph
         @param [in] u origin node of the shortcut
         @param [in] v shortcuted node
         @param [in] w destination node of the shortcut
@@ -420,7 +441,8 @@ class contractionGraph : public Pgr_base_graph<G, CH_vertex, CH_edge, t_directed
     /*!
         @brief print the graph with contracted vertices of all vertices and edges
     */
-    friend std::ostream &operator<<(std::ostream &os, const contractionGraph &g) {
+    friend std::ostream &operator<<(
+            std::ostream &os, const contractionGraph &g) {
         EO_i out, out_end;
         for (const auto &vi : boost::make_iterator_range(vertices(g.graph))) {
             if ((*vi) >= g.num_vertices())

--- a/include/contraction/contractionGraph.hpp
+++ b/include/contraction/contractionGraph.hpp
@@ -133,6 +133,13 @@ class contractionGraph :
         }
     }
 
+    void set_vertices_order(
+            std::vector< std::pair<int64_t, int64_t> > vertices) {
+        for (const auto &v : vertices) {
+            this->graph[this->vertices_map[v.first]].set_order(v.second);
+        }
+    }
+
     // Other member functions
     /*!
         @brief add a shortcut to the graph during contraction

--- a/include/cpp_common/bidirectional.hpp
+++ b/include/cpp_common/bidirectional.hpp
@@ -55,7 +55,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 namespace pgrouting {
 namespace bidirectional {
 
-
 template < typename G >
 class Pgr_bidirectional {
  protected:

--- a/include/cpp_common/orderedVertex_t.hpp
+++ b/include/cpp_common/orderedVertex_t.hpp
@@ -1,0 +1,40 @@
+/*PGR-GNU*****************************************************************
+File: edge_xy_t.hpp
+
+Copyright (c) 2017 pgRouting developers
+Mail: project@pgrouting.org
+
+Oslandia - Aurélie Bousquet - 2024
+Mail: aurelie.bousquet@oslandia.com / contact@oslandia.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+/*! @file */
+
+#ifndef INCLUDE_CPP_COMMON_ORDERED_VERTEX_T_HPP_
+#define INCLUDE_CPP_COMMON_ORDERED_VERTEX_T_HPP_
+#pragma once
+
+#include <cstdint>
+
+struct OrderedVertex_t {
+    int64_t id;
+    int64_t order;
+};
+
+#endif  // INCLUDE_CPP_COMMON_ORDERED_VERTEX_T_HPP_

--- a/include/cpp_common/pgdata_fetchers.hpp
+++ b/include/cpp_common/pgdata_fetchers.hpp
@@ -44,6 +44,7 @@ extern "C" {
 #include <access/htup_details.h>
 }
 
+#include <utility>
 #include <vector>
 
 #include "cpp_common/undefPostgresDefine.hpp"
@@ -56,6 +57,7 @@ extern "C" {
 #include "cpp_common/costFlow_t.hpp"
 #include "cpp_common/edge_xy_t.hpp"
 #include "cpp_common/edge_t.hpp"
+#include "cpp_common/orderedVertex_t.hpp"
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/orders_t.hpp"
 #include "cpp_common/restriction_t.hpp"
@@ -91,6 +93,11 @@ Edge_t fetch_edge(
         int64_t*, size_t*, bool);
 
 Edge_xy_t fetch_edge_xy(
+        const HeapTuple, const TupleDesc &,
+        const std::vector<Column_info_t> &,
+        int64_t*, size_t*, bool);
+
+OrderedVertex_t fetch_ordered_vertices(
         const HeapTuple, const TupleDesc &,
         const std::vector<Column_info_t> &,
         int64_t*, size_t*, bool);

--- a/include/cpp_common/pgdata_getters.hpp
+++ b/include/cpp_common/pgdata_getters.hpp
@@ -53,6 +53,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/costFlow_t.hpp"
 #include "cpp_common/edge_xy_t.hpp"
 #include "cpp_common/edge_t.hpp"
+#include "cpp_common/orderedVertex_t.hpp"
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/orders_t.hpp"
 #include "cpp_common/restriction_t.hpp"
@@ -81,6 +82,9 @@ std::vector<Delauny_t> get_delauny(const std::string&);
 
 /** @brief Read edges */
 std::vector<Edge_t> get_edges(const std::string&, bool, bool);
+
+/** @brief Read ordered vertices */
+std::vector<OrderedVertex_t> get_ordered_vertices(const std::string&);
 
 /** @brief Read edges with x, y endpoints */
 std::vector<Edge_xy_t> get_edges_xy(const std::string&, bool);

--- a/sql/contraction/_bdhDijkstra.sql
+++ b/sql/contraction/_bdhDijkstra.sql
@@ -1,0 +1,85 @@
+/*PGR-GNU*****************************************************************
+
+Copyright (c) 2017 pgRouting developers
+Mail: project@pgrouting.org
+
+Oslandia - Aurélie Bousquet - 2024
+Mail: aurelie.bousquet@oslandia.com / contact@oslandia.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+
+-------------
+-------------
+-- bdhDijkstra
+-------------
+-------------
+
+
+--v3.0
+CREATE FUNCTION _pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- nodes_sql (required)
+    ANYARRAY, -- start_vids (required)
+    ANYARRAY, -- end_vids (required)
+
+    directed BOOLEAN,
+    only_cost BOOLEAN DEFAULT false,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT start_vid BIGINT,
+    OUT end_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+'MODULE_PATHNAME'
+LANGUAGE c VOLATILE STRICT;
+
+
+--v3.2
+CREATE FUNCTION _pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- nodes_sql (required)
+    TEXT,     -- combinations_sql (required)
+
+    directed BOOLEAN,
+    only_cost BOOLEAN DEFAULT false,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT start_vid BIGINT,
+    OUT end_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+'MODULE_PATHNAME'
+LANGUAGE c VOLATILE STRICT;
+
+
+-- COMMENTS
+
+COMMENT ON FUNCTION _pgr_bdhDijkstra(TEXT, ANYARRAY, ANYARRAY, BOOLEAN, BOOLEAN)
+IS 'pgRouting internal function';
+
+COMMENT ON FUNCTION _pgr_bdhDijkstra(TEXT, TEXT, BOOLEAN, BOOLEAN)
+IS 'pgRouting internal function';

--- a/sql/contraction/bdhDijkstra.sql
+++ b/sql/contraction/bdhDijkstra.sql
@@ -1,0 +1,233 @@
+/*PGR-GNU*****************************************************************
+
+Copyright (c) 2017 pgRouting developers
+Mail: project@pgrouting.org
+
+Oslandia - Aurélie Bousquet - 2024
+Mail: aurelie.bousquet@oslandia.com / contact@oslandia.com
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+
+
+-------------------
+-- pgr_bdhDijkstra
+-------------------
+
+
+-- ONE TO ONE
+--v2.6
+CREATE FUNCTION pgr_bdhDijkstra(
+    TEXT,   -- edges_sql (required)
+    TEXT,   -- vertices_sql (required)
+    BIGINT, -- from_vid
+    BIGINT, -- to_vid
+
+    directed BOOLEAN DEFAULT true,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+$BODY$
+    SELECT seq, path_seq, node, edge, cost, agg_cost
+    FROM _pgr_bdhDijkstra(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], ARRAY[$3]::BIGINT[], $4, false);
+$BODY$
+LANGUAGE sql VOLATILE STRICT
+COST 100
+ROWS 1000;
+
+
+-- ONE TO MANY
+--v2.6
+CREATE FUNCTION pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- vertices_sql (required)
+    BIGINT,   -- from_vid (required)
+    ANYARRAY, -- to_vids (required)
+
+    directed BOOLEAN DEFAULT TRUE,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT end_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+$BODY$
+    SELECT seq, path_seq, end_vid, node, edge, cost, agg_cost
+    FROM _pgr_bdhDijkstra(_pgr_get_statement($1), ARRAY[$2]::BIGINT[], $3::BIGINT[], $4, false);
+$BODY$
+LANGUAGE sql VOLATILE STRICT
+COST 100
+ROWS 1000;
+
+
+-- MANY TO ONE
+--v2.6
+CREATE FUNCTION pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- vertices_sql (required)
+    ANYARRAY, -- from_vids (required)
+    BIGINT,   -- to_vid (required)
+
+    directed BOOLEAN DEFAULT TRUE,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT start_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+$BODY$
+    SELECT seq, path_seq, start_vid, node, edge, cost, agg_cost
+    FROM _pgr_bdhDijkstra(_pgr_get_statement($1), $2::BIGINT[], ARRAY[$3]::BIGINT[], $4, false);
+$BODY$
+LANGUAGE sql VOLATILE STRICT
+COST 100
+ROWS 1000;
+
+
+
+-- MANY TO MANY
+--v2.6
+CREATE FUNCTION pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- vertices_sql (required)
+    ANYARRAY, -- from_vids (required)
+    ANYARRAY, -- to_vids (required)
+
+    directed BOOLEAN DEFAULT TRUE,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT start_vid BIGINT,
+    OUT end_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+$BODY$
+    SELECT seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost
+    FROM _pgr_bdhDijkstra(_pgr_get_statement($1), $2::BIGINT[], $3::BIGINT[], directed, false);
+$BODY$
+LANGUAGE SQL VOLATILE STRICT
+COST 100
+ROWS 1000;
+
+
+-- COMBINATIONS
+--v3.2
+CREATE FUNCTION pgr_bdhDijkstra(
+    TEXT,     -- edges_sql (required)
+    TEXT,     -- vertices_sql (required)
+    TEXT,     -- combinations_sql (required)
+
+    directed BOOLEAN DEFAULT TRUE,
+
+    OUT seq INTEGER,
+    OUT path_seq INTEGER,
+    OUT start_vid BIGINT,
+    OUT end_vid BIGINT,
+    OUT node BIGINT,
+    OUT edge BIGINT,
+    OUT cost FLOAT,
+    OUT agg_cost FLOAT)
+RETURNS SETOF RECORD AS
+$BODY$
+    SELECT seq, path_seq, start_vid, end_vid, node, edge, cost, agg_cost
+    FROM _pgr_bdhDijkstra(_pgr_get_statement($1), _pgr_get_statement($2), directed, false);
+$BODY$
+LANGUAGE SQL VOLATILE STRICT
+COST 100
+ROWS 1000;
+
+
+-- COMMENTS
+
+COMMENT ON FUNCTION pgr_bdhDijkstra(TEXT, BIGINT, BIGINT, BOOLEAN)
+IS 'pgr_bdDijkstra(One to One)
+- Parameters:
+  - Edges SQL with columns: id, source, target, cost [,reverse_cost]
+  - Nodes SQL with columns: id, vertex_order
+  - From vertex identifier
+  - To vertex identifier
+- Optional Parameters:
+  - directed := true
+- Documentation:
+  - ${PROJECT_DOC_LINK}/pgr_bdhDijkstra.html
+';
+
+COMMENT ON FUNCTION pgr_bdhDijkstra(TEXT, BIGINT, ANYARRAY, BOOLEAN)
+IS 'pgr_bdDijkstra(One to Many)
+- Parameters:
+  - Edges SQL with columns: id, source, target, cost [,reverse_cost]
+  - Nodes SQL with columns: id, vertex_order
+  - From vertex identifier
+  - To ARRAY[vertices identifiers]
+- Optional Parameters
+  - directed := true
+- Documentation:
+  - ${PROJECT_DOC_LINK}/pgr_bdhDijkstra.html
+';
+
+COMMENT ON FUNCTION pgr_bdhDijkstra(TEXT, ANYARRAY, BIGINT, BOOLEAN)
+IS 'pgr_bdDijkstra(Many to One)
+- Parameters:
+  - Edges SQL with columns: id, source, target, cost [,reverse_cost]
+  - Nodes SQL with columns: id, vertex_order
+  - From ARRAY[vertices identifiers]
+  - To vertex identifier
+- Optional Parameters
+  - directed := true
+- Documentation:
+  - ${PROJECT_DOC_LINK}/pgr_bdhDijkstra.html
+';
+
+COMMENT ON FUNCTION pgr_bdhDijkstra(TEXT, ANYARRAY, ANYARRAY, BOOLEAN)
+IS 'pgr_bdDijkstra(Many to Many)
+- Parameters:
+  - Edges SQL with columns: id, source, target, cost [,reverse_cost]
+  - Nodes SQL with columns: id, vertex_order
+  - From ARRAY[vertices identifiers]
+  - To ARRAY[vertices identifiers]
+- Optional Parameters
+  - directed := true
+- Documentation:
+  - ${PROJECT_DOC_LINK}/pgr_bdhDijkstra.html
+';
+
+COMMENT ON FUNCTION pgr_bdhDijkstra(TEXT, TEXT, BOOLEAN)
+IS 'pgr_bdDijkstra(Combinations)
+- Parameters:
+  - Edges SQL with columns: id, source, target, cost [,reverse_cost]
+  - Nodes SQL with columns: id, vertex_order
+  - Combinations SQL with columns: source, target
+- Optional Parameters
+  - directed := true
+- Documentation:
+  - ${PROJECT_DOC_LINK}/pgr_bdhDijkstra.html
+';

--- a/src/contraction/bdhDijkstra.c
+++ b/src/contraction/bdhDijkstra.c
@@ -1,0 +1,184 @@
+/*PGR-GNU*****************************************************************
+File: bdDijkstra.c
+
+Generated with Template by:
+Copyright (c) 2016 pgRouting developers
+Mail: project@pgrouting.org
+
+Function's developer:
+Copyright (c) 2016 Celia Virginia Vergara Castillo
+Mail: vicky at erosion.dev
+
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+
+#include <stdbool.h>
+#include "c_common/postgres_connection.h"
+
+#include "c_types/path_rt.h"
+#include "c_common/debug_macro.h"
+#include "c_common/e_report.h"
+#include "c_common/time_msg.h"
+#include "drivers/bdhDijkstra/bdhDijkstra_driver.h"
+
+PGDLLEXPORT Datum _pgr_bdhDijkstra(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(_pgr_bdhDijkstra);
+
+static void
+process(
+        char *edges_sql,
+        char *vertices_sql,
+        char *combinations_sql,
+        ArrayType *starts,
+        ArrayType *ends,
+
+        bool directed,
+        bool only_cost,
+        Path_rt **result_tuples,
+        size_t *result_count) {
+    pgr_SPI_connect();
+    char* log_msg = NULL;
+    char* notice_msg = NULL;
+    char* err_msg = NULL;
+
+    clock_t start_t = clock();
+    pgr_do_bdhDijkstra(
+            edges_sql,
+            vertices_sql,
+            combinations_sql,
+            starts, ends,
+
+            directed,
+            only_cost,
+
+            result_tuples,
+            result_count,
+            &log_msg,
+            &notice_msg,
+            &err_msg);
+    time_msg(" processing pgr_bdhDijkstra", start_t, clock());
+
+    if (err_msg && (*result_tuples)) {
+        pfree(*result_tuples);
+        (*result_tuples) = NULL;
+        (*result_count) = 0;
+    }
+
+    pgr_global_report(&log_msg, &notice_msg, &err_msg);
+
+    pgr_SPI_finish();
+}
+
+
+PGDLLEXPORT Datum _pgr_bdhDijkstra(PG_FUNCTION_ARGS) {
+    FuncCallContext     *funcctx;
+    TupleDesc            tuple_desc;
+
+    Path_rt  *result_tuples = NULL;
+    size_t result_count = 0;
+
+    if (SRF_IS_FIRSTCALL()) {
+        MemoryContext   oldcontext;
+        funcctx = SRF_FIRSTCALL_INIT();
+        oldcontext = MemoryContextSwitchTo(funcctx->multi_call_memory_ctx);
+        if (PG_NARGS() == 6) {
+            /*
+             * many to many
+             */
+            process(
+                text_to_cstring(PG_GETARG_TEXT_P(0)),
+                text_to_cstring(PG_GETARG_TEXT_P(1)),
+                NULL,
+                PG_GETARG_ARRAYTYPE_P(2),
+                PG_GETARG_ARRAYTYPE_P(3),
+                PG_GETARG_BOOL(4),
+                PG_GETARG_BOOL(5),
+                &result_tuples,
+                &result_count);
+
+        } else if (PG_NARGS() == 5) {
+            /*
+             * combinations
+             */
+            process(
+                text_to_cstring(PG_GETARG_TEXT_P(0)),
+                text_to_cstring(PG_GETARG_TEXT_P(1)),
+                text_to_cstring(PG_GETARG_TEXT_P(2)),
+                NULL,
+                NULL,
+                PG_GETARG_BOOL(3),
+                PG_GETARG_BOOL(4),
+                &result_tuples,
+                &result_count);
+        }
+
+        funcctx->max_calls = result_count;
+        funcctx->user_fctx = result_tuples;
+        if (get_call_result_type(fcinfo, NULL, &tuple_desc)
+                != TYPEFUNC_COMPOSITE) {
+            ereport(ERROR,
+                    (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+                     errmsg("function returning record called in context "
+                         "that cannot accept type record")));
+        }
+
+        funcctx->tuple_desc = tuple_desc;
+        MemoryContextSwitchTo(oldcontext);
+    }
+
+    funcctx = SRF_PERCALL_SETUP();
+    tuple_desc = funcctx->tuple_desc;
+    result_tuples = (Path_rt*) funcctx->user_fctx;
+
+    if (funcctx->call_cntr < funcctx->max_calls) {
+        HeapTuple    tuple;
+        Datum        result;
+        Datum        *values;
+        bool*        nulls;
+        size_t       call_cntr = funcctx->call_cntr;
+
+        size_t numb = 8;
+        values = palloc(numb * sizeof(Datum));
+        nulls = palloc(numb * sizeof(bool));
+
+        size_t i;
+        for (i = 0; i < numb; ++i) {
+            nulls[i] = false;
+        }
+
+        int64_t seq = call_cntr == 0?  1 : result_tuples[call_cntr - 1].start_id;
+
+        values[0] = Int32GetDatum((int32_t)call_cntr + 1);
+        values[1] = Int32GetDatum((int32_t)seq);
+        values[2] = Int64GetDatum(result_tuples[call_cntr].start_id);
+        values[3] = Int64GetDatum(result_tuples[call_cntr].end_id);
+        values[4] = Int64GetDatum(result_tuples[call_cntr].node);
+        values[5] = Int64GetDatum(result_tuples[call_cntr].edge);
+        values[6] = Float8GetDatum(result_tuples[call_cntr].cost);
+        values[7] = Float8GetDatum(result_tuples[call_cntr].agg_cost);
+
+        result_tuples[call_cntr].start_id = result_tuples[call_cntr].edge < 0? 1 : seq + 1;
+
+        tuple = heap_form_tuple(tuple_desc, values, nulls);
+        result = HeapTupleGetDatum(tuple);
+        SRF_RETURN_NEXT(funcctx, result);
+    } else {
+        SRF_RETURN_DONE(funcctx);
+    }
+}

--- a/src/contraction/bdhDijkstra_driver.cpp
+++ b/src/contraction/bdhDijkstra_driver.cpp
@@ -1,0 +1,205 @@
+/*PGR-GNU*****************************************************************
+File: bdDijkstra_driver.cpp
+
+Generated with Template by:
+Copyright (c) 2015 pgRouting developers
+Mail: project@pgrouting.org
+
+Function's developer:
+Copyright (c) 2016 Celia Virginia Vergara Castillo
+Mail: vicky at erosion.dev
+
+------
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ ********************************************************************PGR-GNU*/
+
+#include "drivers/bdhDijkstra/bdhDijkstra_driver.h"
+
+#include <sstream>
+#include <deque>
+#include <vector>
+#include <algorithm>
+#include <string>
+#include <map>
+#include <set>
+
+
+#include "cpp_common/combinations.hpp"
+#include "cpp_common/pgdata_getters.hpp"
+#include "cpp_common/alloc.hpp"
+#include "cpp_common/assert.hpp"
+#include "cpp_common/base_graph.hpp"
+#include "contraction/bdhDijkstra.hpp"
+#include "contraction/ch_graph.hpp"
+
+#include "c_types/ii_t_rt.h"
+
+
+
+namespace {
+
+template < class G >
+std::deque<pgrouting::Path>
+pgr_bdhDijkstra(
+        G &graph,
+        const std::map<int64_t, std::set<int64_t>> &combinations,
+        bool only_cost) {
+    using pgrouting::Path;
+
+    pgrouting::bidirectional::Pgr_bdhDijkstra<G> fn_bdhDijkstra(graph);
+    std::deque<Path> paths;
+
+    for (const auto &comb : combinations) {
+        auto source = comb.first;
+        if (!graph.has_vertex(source)) continue;
+
+        for (const auto &target : comb.second) {
+            if (!graph.has_vertex(target)) continue;
+            fn_bdDijkstra.clear();
+
+            paths.push_back(fn_bdhDijkstra.pgr_bdhDijkstra(
+                graph.get_V(source), graph.get_V(target), only_cost));
+        }
+    }
+    return paths;
+}
+
+}  // namespace
+
+void
+pgr_do_bdhDijkstra(
+        char *edges_sql,
+        char *vertices_sql,
+        char *combinations_sql,
+        ArrayType *starts,
+        ArrayType *ends,
+
+        bool directed,
+        bool only_cost,
+
+        Path_rt **return_tuples,
+        size_t *return_count,
+        char **log_msg,
+        char **notice_msg,
+        char **err_msg) {
+    using pgrouting::Path;
+    using pgrouting::pgr_alloc;
+    using pgrouting::pgr_msg;
+    using pgrouting::pgr_free;
+    using pgrouting::utilities::get_combinations;
+
+    std::ostringstream log;
+    std::ostringstream err;
+    std::ostringstream notice;
+    char *hint = nullptr;
+
+    try {
+        pgassert(!(*log_msg));
+        pgassert(!(*notice_msg));
+        pgassert(!(*err_msg));
+        pgassert(!(*return_tuples));
+        pgassert(*return_count == 0);
+
+        hint = combinations_sql;
+        auto combinations = get_combinations(
+            combinations_sql, starts, ends, true);
+        hint = nullptr;
+
+        if (combinations.empty() && combinations_sql) {
+            *notice_msg = pgr_msg("No (source, target) pairs found");
+            *log_msg = pgr_msg(combinations_sql);
+            return;
+        }
+
+        hint = edges_sql;
+        auto edges = pgrouting::pgget::get_edges(
+            std::string(edges_sql), true, false);
+
+        if (edges.empty()) {
+            *notice_msg = pgr_msg("No edges found");
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            return;
+        }
+        hint = nullptr;
+
+        hint = vertices_sql;
+        auto vertices = pgrouting::pgget::get_ordered_vertices(
+            std::string(vertices_sql));
+
+        if (vertices.empty()) {
+            *notice_msg = pgr_msg("No vertices found");
+            *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+            return;
+        }
+        hint = nullptr;
+
+        std::deque<Path> paths;
+
+        if (directed) {
+            pgrouting::graph::CHDirectedGraph graph;
+            graph.insert_edges(edges);
+            graph.set_vertices_order(vertices);
+            paths = pgr_bdhDijkstra(graph, combinations, only_cost);
+        } else {
+            pgrouting::graph::CHUndirectedGraph graph;
+            graph.insert_edges(edges);
+            graph.set_vertices_order(vertices);
+            paths = pgr_bdhDijkstra(graph, combinations, only_cost);
+        }
+
+        auto count = count_tuples(paths);
+
+        if (count == 0) {
+            (*return_tuples) = NULL;
+            (*return_count) = 0;
+            notice << "No paths found";
+            *log_msg = pgr_msg(notice.str().c_str());
+            return;
+        }
+
+        (*return_tuples) = pgr_alloc(count, (*return_tuples));
+        (*return_count) = (collapse_paths(return_tuples, paths));
+
+        *log_msg = log.str().empty()?
+            *log_msg :
+            pgr_msg(log.str().c_str());
+        *notice_msg = notice.str().empty()?
+            *notice_msg :
+            pgr_msg(notice.str().c_str());
+    } catch (AssertFailedException &except) {
+        (*return_tuples) = pgr_free(*return_tuples);
+        (*return_count) = 0;
+        err << except.what();
+        *err_msg = pgr_msg(err.str().c_str());
+        *log_msg = pgr_msg(log.str().c_str());
+    } catch (const std::string &ex) {
+        *err_msg = pgr_msg(ex.c_str());
+        *log_msg = hint? pgr_msg(hint) : pgr_msg(log.str().c_str());
+    } catch (std::exception &except) {
+        (*return_tuples) = pgr_free(*return_tuples);
+        (*return_count) = 0;
+        err << except.what();
+        *err_msg = pgr_msg(err.str().c_str());
+        *log_msg = pgr_msg(log.str().c_str());
+    } catch(...) {
+        (*return_tuples) = pgr_free(*return_tuples);
+        (*return_count) = 0;
+        err << "Caught unknown exception!";
+        *err_msg = pgr_msg(err.str().c_str());
+        *log_msg = pgr_msg(log.str().c_str());
+    }
+}

--- a/src/cpp_common/pgdata_fetchers.cpp
+++ b/src/cpp_common/pgdata_fetchers.cpp
@@ -49,6 +49,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #include "cpp_common/delauny_t.hpp"
 #include "c_types/edge_bool_t_rt.h"
 #include "cpp_common/costFlow_t.hpp"
+#include "cpp_common/orderedVertex_t.hpp"
 #include "cpp_common/edge_xy_t.hpp"
 #include "cpp_common/edge_t.hpp"
 #include "c_types/iid_t_rt.h"
@@ -267,6 +268,19 @@ Edge_xy_t fetch_edge_xy(
     *valid_edges = edge.cost < 0? *valid_edges: *valid_edges + 1;
     *valid_edges = edge.reverse_cost < 0? *valid_edges: *valid_edges + 1;
     return edge;
+}
+
+OrderedVertex_t fetch_ordered_vertices(
+        const HeapTuple tuple,
+        const TupleDesc &tupdesc,
+        const std::vector<Column_info_t> &info,
+        int64_t *,
+        size_t *,
+        bool) {
+    OrderedVertex_t ordered_vertex;
+    ordered_vertex.id = getBigInt(tuple, tupdesc, info[0]);
+    ordered_vertex.order = getBigInt(tuple, tupdesc, info[1]);
+    return ordered_vertex;
 }
 
 IID_t_rt pgr_fetch_row(

--- a/src/cpp_common/pgdata_getters.cpp
+++ b/src/cpp_common/pgdata_getters.cpp
@@ -67,6 +67,7 @@ extern "C" {
 #include "c_types/iid_t_rt.h"
 #include "cpp_common/delauny_t.hpp"
 #include "cpp_common/edge_t.hpp"
+#include "cpp_common/orderedVertex_t.hpp"
 #include "c_types/edge_bool_t_rt.h"
 #include "cpp_common/edge_xy_t.hpp"
 #include "cpp_common/orders_t.hpp"
@@ -290,6 +291,26 @@ std::vector<Edge_t> get_edges(
     return get_data<Edge_t>(sql, normal, info, &fetch_edge);
 }
 
+/**
+
+  For queries of the type:
+  ~~~~{.c}
+  SELECT id, order FROM vertices_table;
+  ~~~~
+
+  @param[in] sql The query
+  @returns vector of pairs of int64_t
+  */
+std::vector<OrderedVertex_t> get_ordered_vertices(
+        const std::string &sql) {
+    using pgrouting::Column_info_t;
+    std::vector<Column_info_t> info{
+    {-1, 0, true, "id", ANY_INTEGER},
+    {-1, 0, true, "order", ANY_INTEGER}};
+
+    return get_data< OrderedVertex_t >(
+        sql, true, info, &fetch_ordered_vertices);
+}
 
 /**
 

--- a/src/cpp_common/pgdata_getters.cpp
+++ b/src/cpp_common/pgdata_getters.cpp
@@ -277,7 +277,8 @@ std::vector<Edge_xy_t> get_edges_xy(const std::string &sql, bool normal) {
   @param[in] ignore_id when true id value of edge is ignored
   @returns vector of `Edge_t`
   */
-std::vector<Edge_t> get_edges(const std::string &sql, bool normal, bool ignore_id) {
+std::vector<Edge_t> get_edges(
+        const std::string &sql, bool normal, bool ignore_id) {
     using pgrouting::Column_info_t;
     std::vector<Column_info_t> info{
     {-1, 0, !ignore_id, "id", ANY_INTEGER},


### PR DESCRIPTION
This PR implements the shortest path algorithm for graphs having a contraction hierarchy. A new function is implemented inside the `contraction` module. 

The implementation is based on the one of `bdDijkstra`. A refinement has been introduced to take into account the hierarchy. 
- The search from the origin is done on the upward graph, which only contains edges from `v` to `w` where `v > w`;
- The search from the destination is done on the downward graph, which only contains edges from `v` to `w` where `v < w`.


