### PR TITLE
Fix documentation contraction

### DIFF
--- a/doc/contraction/pgr_contraction.rst
+++ b/doc/contraction/pgr_contraction.rst
@@ -263,13 +263,6 @@ In this section, building and using a contracted graph will be shown by example.
 - The :doc:`sampledata` for an undirected graph is used
 - a dead end operation first followed by a linear operation.
 
-
-.. contents::
-   :local:
-
-Construction of the graph in the database
-...............................................................................
-
 The original graph:
 
 .. image:: /images/Fig6-undirected.png
@@ -296,7 +289,7 @@ After doing the linear contraction operation to the graph above:
 .. image:: images/undirected_sampledata_c.png
    :scale: 25%
 
-The process to create the contraction graph on the database:
+Creating the contraction graph in the database
 -------------------------------------------------------------------------------
 
 .. contents::

--- a/doc/contraction/pgr_contractionDeadEnd.rst
+++ b/doc/contraction/pgr_contractionDeadEnd.rst
@@ -14,7 +14,7 @@
 
 |
 
-``pgr_contractionDeadEnd`` - Proposed
+``pgr_contractionDeadEnd``
 ===============================================================================
 
 ``pgr_contractionDeadEnd`` — Performs graph contraction and returns the contracted
@@ -28,7 +28,7 @@ vertices and edges.
 
 * Version 3.8.0
 
-  * New proposed function.
+  * New **proposed** function.
 
 Description
 -------------------------------------------------------------------------------

--- a/doc/contraction/pgr_contractionLinear.rst
+++ b/doc/contraction/pgr_contractionLinear.rst
@@ -14,7 +14,7 @@
 
 |
 
-``pgr_contractionLinear`` - Proposed
+``pgr_contractionLinear``
 ===============================================================================
 
 ``pgr_contractionLinear`` — Performs graph contraction and returns the contracted
@@ -24,7 +24,7 @@ vertices and edges.
 
 * Version 3.8.0
 
-  * New proposed function.
+  * New **proposed** function.
 
 
 Description
@@ -55,7 +55,7 @@ Signatures
 
 - The green nodes are linear nodes and will not be part of the contracted graph.
 
-  - All edges adjacent will not be part of the contracted graph.
+  - All adjacent edges will not be part of the contracted graph.
 
 - The red lines will be new edges of the contracted graph.
 
@@ -104,12 +104,6 @@ Parameters
    * - `Edges SQL`_
      - ``TEXT``
      - `Edges SQL`_ as described below.
-   * - **contraction Order**
-     - ``ARRAY[`` **ANY-INTEGER** ``]``
-     - Ordered contraction operations.
-
-       - 1 = Dead end contraction
-       - 2 = Linear contraction
 
 Optional parameters
 ...............................................................................
@@ -134,11 +128,6 @@ Contraction optional parameters
      - ``ARRAY[`` **ANY-INTEGER** ``]``
      - **Empty**
      - Identifiers of vertices forbidden for contraction.
-   * - ``cycles``
-     - ``INTEGER``
-     - :math:`1`
-     - Number of times the contraction operations on ``contraction_order`` will
-       be performed.
 
 Inner Queries
 -------------------------------------------------------------------------------

--- a/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
+++ b/locale/en/LC_MESSAGES/pgrouting_doc_strings.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v3.8\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-11 20:19+0000\n"
+"POT-Creation-Date: 2025-04-15 16:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -9233,9 +9233,6 @@ msgstr ""
 msgid "a dead end operation first followed by a linear operation."
 msgstr ""
 
-msgid "Construction of the graph in the database"
-msgstr ""
-
 msgid "The original graph:"
 msgstr ""
 
@@ -9256,7 +9253,7 @@ msgstr ""
 msgid "After doing the linear contraction operation to the graph above:"
 msgstr ""
 
-msgid "The process to create the contraction graph on the database:"
+msgid "Creating the contraction graph in the database"
 msgstr ""
 
 msgid "Add additional columns"
@@ -9378,12 +9375,15 @@ msgstr ""
 msgid "Case 3: Source and/or target belong to a vertex that has been contracted."
 msgstr ""
 
-msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgid "``pgr_contractionDeadEnd``"
 msgstr ""
 
 msgid ""
 "``pgr_contractionDeadEnd`` — Performs graph contraction and returns the "
 "contracted vertices and edges."
+msgstr ""
+
+msgid "New **proposed** function."
 msgstr ""
 
 msgid "A node is considered a dead end node when:"
@@ -9579,7 +9579,7 @@ msgstr ""
 msgid "Using when departure and destination are not in the contracted graph"
 msgstr ""
 
-msgid "``pgr_contractionLinear`` - Proposed"
+msgid "``pgr_contractionLinear``"
 msgstr ""
 
 msgid ""
@@ -9598,18 +9598,10 @@ msgid ""
 "graph."
 msgstr ""
 
-msgid "All edges adjacent will not be part of the contracted graph."
+msgid "All adjacent edges will not be part of the contracted graph."
 msgstr ""
 
 msgid "The red lines will be new edges of the contracted graph."
-msgstr ""
-
-msgid "**contraction Order**"
-msgstr ""
-
-msgid ""
-"Number of times the contraction operations on ``contraction_order`` will "
-"be performed."
 msgstr ""
 
 msgid "A node connects two (or more) `linear` edges when"

--- a/locale/pot/pgrouting_doc_strings.pot
+++ b/locale/pot/pgrouting_doc_strings.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: pgRouting v4.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-04-11 20:19+0000\n"
+"POT-Creation-Date: 2025-04-15 16:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -7972,9 +7972,6 @@ msgstr ""
 msgid "a dead end operation first followed by a linear operation."
 msgstr ""
 
-msgid "Construction of the graph in the database"
-msgstr ""
-
 msgid "The original graph:"
 msgstr ""
 
@@ -7990,7 +7987,7 @@ msgstr ""
 msgid "After doing the linear contraction operation to the graph above:"
 msgstr ""
 
-msgid "The process to create the contraction graph on the database:"
+msgid "Creating the contraction graph in the database"
 msgstr ""
 
 msgid "Add additional columns"
@@ -8092,10 +8089,13 @@ msgstr ""
 msgid "Case 3: Source and/or target belong to a vertex that has been contracted."
 msgstr ""
 
-msgid "``pgr_contractionDeadEnd`` - Proposed"
+msgid "``pgr_contractionDeadEnd``"
 msgstr ""
 
 msgid "``pgr_contractionDeadEnd`` — Performs graph contraction and returns the contracted vertices and edges."
+msgstr ""
+
+msgid "New **proposed** function."
 msgstr ""
 
 msgid "A node is considered a dead end node when:"
@@ -8272,7 +8272,7 @@ msgstr ""
 msgid "Using when departure and destination are not in the contracted graph"
 msgstr ""
 
-msgid "``pgr_contractionLinear`` - Proposed"
+msgid "``pgr_contractionLinear``"
 msgstr ""
 
 msgid "``pgr_contractionLinear`` — Performs graph contraction and returns the contracted vertices and edges."
@@ -8287,16 +8287,10 @@ msgstr ""
 msgid "The green nodes are linear nodes and will not be part of the contracted graph."
 msgstr ""
 
-msgid "All edges adjacent will not be part of the contracted graph."
+msgid "All adjacent edges will not be part of the contracted graph."
 msgstr ""
 
 msgid "The red lines will be new edges of the contracted graph."
-msgstr ""
-
-msgid "**contraction Order**"
-msgstr ""
-
-msgid "Number of times the contraction operations on ``contraction_order`` will be performed."
 msgstr ""
 
 msgid "A node connects two (or more) `linear` edges when"


### PR DESCRIPTION
Changes proposed in this pull request:
- remove parts of the documentation in linear contraction, which now belong to the `pgr_contraction` function
- reorganize to improve homogeneity and clarity.

@pgRouting/admins
